### PR TITLE
Minor fixes for mc and rest containers

### DIFF
--- a/conf/docker-compose.yml
+++ b/conf/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
       CATALOG_S3_ENDPOINT: http://minio:9090
       CATALOG_URI: jdbc:postgresql://postgres:5432/metastore_db
+    entrypoint: >
+      /bin/sh -c "
+      until (openssl s_client -connect postgres:5432 | grep 'Verification: OK') do echo '...waiting...' && sleep 1; done;
+      java -jar iceberg-rest-image-all.jar
+      "
     networks:
       - presto-network
     depends_on:
@@ -81,7 +86,7 @@ services:
       AWS_REGION: us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9090 minio minio123) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9090 minio minio123) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;


### PR DESCRIPTION
Changes:
- `mc` container: fix the command to configure `minio` alias
- `rest` container: add a check to wait for `postgres` to be available

Testing:
Tested on my laptop:

`rest` container will wait for `postgres` to be ready:
```shell
$ docker compose logs rest
WARN[0000] /Users/xxx/training/presto/presto-iceberg-lab/conf/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
iceberg-rest  | 2070EDBEFFFF0000:error:8000006F:system library:BIO_connect:Connection refused:../crypto/bio/bio_sock2.c:125:calling connect()
iceberg-rest  | 2070EDBEFFFF0000:error:10000067:BIO routines:BIO_connect:connect error:../crypto/bio/bio_sock2.c:127:
iceberg-rest  | connect:errno=111
iceberg-rest  | ...waiting...
iceberg-rest  | 20E0DDA0FFFF0000:error:0A000126:SSL routines:ssl3_read_n:unexpected eof while reading:../ssl/record/rec_layer_s3.c:317:
iceberg-rest  | Verification: OK
iceberg-rest  | 2025-06-11T20:34:02.825 INFO  [org.apache.iceberg.rest.RESTCatalogServer] - Creating catalog with properties: {jdbc.password=password, s3.endpoint=http://minio:9090, jdbc.user=user, io-impl=org.apache.iceberg.aws.s3.S3FileIO, catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog, jdbc.schema-version=V1, warehouse=s3://warehouse/, uri=jdbc:postgresql://postgres:5432/metastore_db}
iceberg-rest  | 2025-06-11T20:34:02.842 INFO  [org.apache.iceberg.CatalogUtil] - Loading custom FileIO implementation: org.apache.iceberg.aws.s3.S3FileIO
iceberg-rest  | 2025-06-11T20:34:02.980 INFO  [org.eclipse.jetty.util.log] - Logging initialized @247ms to org.eclipse.jetty.util.log.Slf4jLog
iceberg-rest  | 2025-06-11T20:34:02.999 INFO  [org.eclipse.jetty.server.Server] - jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 17.0.12+7-LTS
iceberg-rest  | 2025-06-11T20:34:03.005 INFO  [org.eclipse.jetty.server.handler.ContextHandler] - Started o.e.j.s.ServletContextHandler@4e5ed836{/,null,AVAILABLE}
iceberg-rest  | 2025-06-11T20:34:03.009 INFO  [org.eclipse.jetty.server.AbstractConnector] - Started ServerConnector@3b0fe47a{HTTP/1.1, (http/1.1)}{0.0.0.0:8181}
iceberg-rest  | 2025-06-11T20:34:03.009 INFO  [org.eclipse.jetty.server.Server] - Started @276ms
```

`mc` container creates `warehouse` bucket:
```shell
$ docker compose up -d minio mc
WARN[0000] /Users/xxx/training/presto/presto-iceberg-lab/conf/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Running 4/4
 ✔ Network conf_presto-network  Created                                                                                                                                                                                                                                        0.2s
 ✔ Volume "conf_minio-data"     Created                                                                                                                                                                                                                                        0.0s
 ✔ Container minio              Started                                                                                                                                                                                                                                        0.3s
 ✔ Container mc                 Started                                                                                                                                                                                                                                        0.4s

$ docker compose exec mc mc ls minio
WARN[0000] /Users/xxx/training/presto/presto-iceberg-lab/conf/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[2025-06-11 20:42:06 UTC]     0B warehouse/
```