### PR TITLE
Update docker-compose.yml

### DIFF
--- a/conf/docker-compose.yml
+++ b/conf/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
       CATALOG_S3_ENDPOINT: http://minio:9090
       CATALOG_URI: jdbc:postgresql://postgres:5432/metastore_db
+    entrypoint: >
+      /bin/sh -c "
+      until (openssl s_client -connect postgres:5432 | grep 'Verification: OK') do echo '...waiting...' && sleep 1; done;
+      java -jar iceberg-rest-image-all.jar
+      "
     networks:
       - presto-network
     depends_on:
@@ -81,7 +86,7 @@ services:
       AWS_REGION: us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9090 minio minio123) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9090 minio minio123) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;

--- a/conf/docker-compose.yml
+++ b/conf/docker-compose.yml
@@ -47,8 +47,6 @@ services:
     image: postgres
     container_name: postgres
     hostname: postgres
-    ports:
-      - 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:

--- a/conf/docker-compose.yml
+++ b/conf/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     container_name: postgres
     hostname: postgres
     ports:
-      - 5433:5432  # todo change this back to 5432
+      - 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
Removed comment and changed the postgres port to only use 5432 in the docker-compose.yml

Tested on MacBook Pro 2023

Removed error when connecting to the REST server

"Caused by: org.postgresql.util.PSQLException: Connection to postgres:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections."